### PR TITLE
Add missing library dependency

### DIFF
--- a/articles/app-service-api/app-service-api-java-api-app.md
+++ b/articles/app-service-api/app-service-api-java-api-app.md
@@ -181,6 +181,7 @@ In this section you'll replace the generated code's server-side implementation w
         import com.sun.jersey.core.header.FormDataContentDisposition;
         import com.sun.jersey.multipart.FormDataParam;
         import javax.ws.rs.core.Response;
+	import javax.ws.rs.core.SecurityContext;
 
         @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JaxRSServerCodegen", date = "2015-11-24T21:54:11.648Z")
         public class ContactsApiServiceImpl extends ContactsApiService {


### PR DESCRIPTION
ContactsApiServiceImpl.java won't compile without importing javax.ws.rs.core.SecurityContext. 
